### PR TITLE
Fix typo in function (deleteOutcomeArchiveByTodoId)

### DIFF
--- a/ongoing-data/src/dbmodule.js
+++ b/ongoing-data/src/dbmodule.js
@@ -340,7 +340,7 @@ exports.getFeelingArchive = async (id) => {
 exports.deleteOutcomeArchiveByTodoId = async (id, todoId) => {
     const result = await OutcomeArchive.deleteOne({
         userId: id,
-        refType: "todo",
+        refType: "ToDo",
         refId: todoId
     })
     return result


### PR DESCRIPTION
Matches the front-side type definition.